### PR TITLE
added styled button component 'StyledButton'

### DIFF
--- a/components/Button/Button.js
+++ b/components/Button/Button.js
@@ -1,7 +1,37 @@
 import React from 'react';
-import Button from 'react-native';
-import buttonStyles from './styles'
+import Button from 'apsl-react-native-button';
+import { buttonStyles } from './styles'
+import colors from '../../styles/colors';
+import { textStyles } from '../../styles/textStyles';
 
-export default class Button extends React.Component {
-	
+export default class StyledButton extends React.Component {
+	render() {
+		if (this.props.primaryButtonLarge) {
+			return (
+				<Button
+				  onPress={this.props.onPress}
+				  style={ buttonStyles.primaryButtonLarge } 
+				  textStyle={ textStyles.buttonText }
+			  	>{this.props.text}</Button>
+			);
+		}
+		if (this.props.primaryButtonSmall) {
+			return (
+				<Button
+				  onPress={this.props.onPress}
+				  style={ buttonStyles.primaryButtonSmall } 
+				  textStyle={ textStyles.buttonText }
+			  	>{this.props.text}</Button>
+			);
+		}
+		if (this.props.clearButtonSmall) {
+			return (
+				<Button
+				  onPress={this.props.onPress}
+				  style={ buttonStyles.clearButtonSmall } 
+				  textStyle={ textStyles.buttonText }
+			  	>{this.props.text}</Button>
+			);
+		}
+	}
 };

--- a/components/Button/Button.js
+++ b/components/Button/Button.js
@@ -29,7 +29,7 @@ export default class StyledButton extends React.Component {
 				<Button
 				  onPress={this.props.onPress}
 				  style={ buttonStyles.clearButtonSmall } 
-				  textStyle={ textStyles.buttonText }
+				  textStyle={ textStyles.buttonTextSmall }
 			  	>{this.props.text}</Button>
 			);
 		}

--- a/components/Button/styles.js
+++ b/components/Button/styles.js
@@ -5,15 +5,25 @@ import { StyleSheet } from 'react-native';
 const buttonStyles = StyleSheet.create({
   primaryButtonLarge: {
     backgroundColor: colors.primaryYellow,
-    color: colors.textLight,
-    fontSize: 20, 
-    fontWeight: '500'
+    borderColor: colors.primaryYellow,
+    marginRight: 16, 
+    marginLeft: 16,
+    marginTop: 24,
+    marginBottom: 8,
   },
 
   primaryButtonSmall: {
+    backgroundColor: colors.primaryYellow,
+    borderColor: colors.primaryYellow,
+    width: 160,
+    marginTop: 24,
+    marginBottom: 8,
   },
 
   clearButtonSmall: {
+    borderColor:'rgba(255, 255, 255, 0)',
+    marginTop: 24,
+    marginBottom: 8,
   },
 });
 

--- a/components/Button/styles.js
+++ b/components/Button/styles.js
@@ -22,8 +22,7 @@ const buttonStyles = StyleSheet.create({
 
   clearButtonSmall: {
     borderColor:'rgba(255, 255, 255, 0)',
-    marginTop: 24,
-    marginBottom: 8,
+    marginBottom: 8, 
   },
 });
 

--- a/components/CourseCard/CourseCard.js
+++ b/components/CourseCard/CourseCard.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { Button, Text, TouchableHighlight, View } from 'react-native';
+import StyledButton from '../../components/Button/Button';
 import { APIRoutes } from '../../config/routes';
 import PropTypes from 'prop-types';
 import { cardStyles } from './styles';
@@ -22,10 +23,11 @@ class CourseCard extends React.Component {
       <TouchableHighlight onPress={() => this.props.onSelectCourse(this.props.course_id)}>
         <View style={cardStyles.container}>
           <Text style={cardStyles.title}>{this.props.course_id} {this.props.title}</Text>
-          <Button
+          <StyledButton
             onPress={() => this.props.onTakeAttendance(this.props.course_id, this.props.title)}
-            title="Take Attendance"
-          />
+            text='Take Attendance'
+            clearButtonSmall>
+          </StyledButton>
         </View>
       </TouchableHighlight>
     );

--- a/components/CourseCard/styles.js
+++ b/components/CourseCard/styles.js
@@ -4,7 +4,7 @@ const cardStyles = StyleSheet.create({
   container: {
     backgroundColor: '#A1C3BB',
     margin: 8,
-    height: 110,
+    height: 124,
   },
   title: {
     padding: 16,

--- a/components/Form/EditTeacherForm.js
+++ b/components/Form/EditTeacherForm.js
@@ -1,10 +1,13 @@
 import React from 'react';
-import { Button, Text, View } from 'react-native';
+import { Text, View } from 'react-native';
+import StyledButton from '../../components/Button/Button';
 import { Form, InputField, PickerField,
          DatePickerField, TimePickerField } from 'react-native-form-generator';
 import { APIRoutes } from '../../config/routes';
 import PropTypes from 'prop-types';
 import { teacherStyles } from '../../styles/teacherStyles';
+import colors from '../../styles/colors';
+import { textStyles } from '../../styles/textStyles';
 
 /**
  * @prop teacher - teacher object information
@@ -68,10 +71,14 @@ class EditTeacherForm extends React.Component {
             value={this.state.teacher.phone}/>
 
         </Form>
-        <Button
+
+        <StyledButton
           onPress={() => this.props.onEditTeacher(this.state.teacher)}
-          title='Save Changes'
-        />
+          text='Save Changes'
+          primaryButtonLarge
+          >
+        </StyledButton>
+
       </View>
     );
   }

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
   },
   "dependencies": {
     "@types/react-native-modalbox": "^1.4.3",
+    "apsl-react-native-button": "^3.1.0",
     "expo": "^21.0.0",
     "moment": "^2.19.1",
     "prop-types": "^15.6.0",

--- a/screens/attendances/AttendanceScreen.js
+++ b/screens/attendances/AttendanceScreen.js
@@ -9,6 +9,7 @@ import { attendanceDate } from '../../lib/date';
 import AttendanceCard from '../../components/AttendanceCard';
 import SimpleModal from '../../components/SimpleModal';
 import { standardError } from '../../lib/request_callbacks';
+import StyledButton from '../../components/Button/Button';
 
 class AttendanceScreen extends React.Component {
   constructor(props) {
@@ -203,7 +204,7 @@ class AttendanceScreen extends React.Component {
             <Text>{this.state.courseTitle}</Text>
             {this._renderAttendances()}
           </ScrollView>
-          <Button
+          <StyledButton
             onPress={() => navigate('AttendanceSummary', {
               attendances: this.state.attendances,
               students: this.state.students,
@@ -211,8 +212,10 @@ class AttendanceScreen extends React.Component {
               date: this.state.date,
               parentKey: this.props.navigation.state.key,
             })}
-            title="Submit"
-          />
+            text='Submit'
+            primaryButtonLarge
+          >
+          </StyledButton>
         </View>
         {this._renderModal()}
       </View>

--- a/styles/textStyles.js
+++ b/styles/textStyles.js
@@ -35,6 +35,12 @@ const textStyles = StyleSheet.create({
     fontWeight: '500'
   },
 
+  buttonTextSmall: {
+    color: colors.textLight,
+    fontSize: 16,
+    fontWeight: '500'
+  },
+
   toastText: {
     color: colors.textLight,
     fontSize: 20


### PR DESCRIPTION
Added styled button component called **StyledButton**

Currently supports the following styles by passing in prop of same name
* **primaryButtonLarge** - For primary call to action buttons (eg: 'Save', 'Submit', 'Sync', etc.) 
* **primaryButtonSmall** - Mainly for modals
* **clearButtonSmall** - For Take Attendance button on course card

To use, import:  
`import StyledButton from '../../components/Button/Button';`

StyledButton accepts:
* onPress function
* text (button label text)
* button style prop (primaryButtonLarge, primaryButtonSmall or clearButtonSmall)
* other stuff that https://github.com/APSL/react-native-button accepts

@loischang @kelseylam 